### PR TITLE
Fix/symlink root path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## [Unreleased]
+### Fixed
+- [Install] Create symlink to `plugin` access `vtex` lib
 
 ## [1.10.0] - 2021-01-07
-- [Install] Create symlink to `plugin` access `vtex` lib
 ### Changed
 - [List] Move command from `index` to `plugins list`
 - [Source] New command that list all `VTEX` plugins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## [Unreleased]
 
-## [1.10.1] - 2021-01-19
+## [1.10.1] - 2021-01-19 (https://github.com/vtex/cli-plugin-plugins/compare/v1.10.0...v1.10.1)
 ### Fixed
-- [Install] Create symlink to `plugin` access `vtex` lib
+- [Install] Fix symlink path to `plugin` access `vtex` lib
 
-## [1.10.0] - 2021-01-07
+## [1.10.0] - 2021-01-07 (https://github.com/vtex/cli-plugin-plugins/compare/v1.9.5...v1.10.0)
 ### Changed
 - [List] Move command from `index` to `plugins list`
 - [Source] New command that list all `VTEX` plugins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased]
+
+## [1.10.1] - 2021-01-19
 ### Fixed
 - [Install] Create symlink to `plugin` access `vtex` lib
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [Unreleased]
 
 ## [1.10.0] - 2021-01-07
-
+- [Install] Create symlink to `plugin` access `vtex` lib
 ### Changed
 - [List] Move command from `index` to `plugins list`
 - [Source] New command that list all `VTEX` plugins

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ EXAMPLES
   $ mycli plugins:install someuser/someplugin
 ```
 
-_See code: [src/commands/plugins/install.ts](https://github.com/vtex/cli-plugin-plugins/blob/v1.10.0/src/commands/plugins/install.ts)_
+_See code: [src/commands/plugins/install.ts](https://github.com/vtex/cli-plugin-plugins/blob/v1.10.1/src/commands/plugins/install.ts)_
 
 ## `mycli plugins:link PLUGIN`
 
@@ -149,7 +149,7 @@ EXAMPLE
   $ mycli plugins:link myplugin
 ```
 
-_See code: [src/commands/plugins/link.ts](https://github.com/vtex/cli-plugin-plugins/blob/v1.10.0/src/commands/plugins/link.ts)_
+_See code: [src/commands/plugins/link.ts](https://github.com/vtex/cli-plugin-plugins/blob/v1.10.1/src/commands/plugins/link.ts)_
 
 ## `mycli plugins:list`
 
@@ -166,7 +166,7 @@ EXAMPLE
   $ mycli plugins list
 ```
 
-_See code: [src/commands/plugins/list.ts](https://github.com/vtex/cli-plugin-plugins/blob/v1.10.0/src/commands/plugins/list.ts)_
+_See code: [src/commands/plugins/list.ts](https://github.com/vtex/cli-plugin-plugins/blob/v1.10.1/src/commands/plugins/list.ts)_
 
 ## `mycli plugins:source PLUGIN`
 
@@ -187,7 +187,7 @@ EXAMPLE
   $ mycli plugins:source myplugin
 ```
 
-_See code: [src/commands/plugins/source.ts](https://github.com/vtex/cli-plugin-plugins/blob/v1.10.0/src/commands/plugins/source.ts)_
+_See code: [src/commands/plugins/source.ts](https://github.com/vtex/cli-plugin-plugins/blob/v1.10.1/src/commands/plugins/source.ts)_
 
 ## `mycli plugins:uninstall PLUGIN...`
 
@@ -209,7 +209,7 @@ ALIASES
   $ mycli plugins:remove
 ```
 
-_See code: [src/commands/plugins/uninstall.ts](https://github.com/vtex/cli-plugin-plugins/blob/v1.10.0/src/commands/plugins/uninstall.ts)_
+_See code: [src/commands/plugins/uninstall.ts](https://github.com/vtex/cli-plugin-plugins/blob/v1.10.1/src/commands/plugins/uninstall.ts)_
 
 ## `mycli plugins:update`
 
@@ -224,5 +224,5 @@ OPTIONS
   -v, --verbose
 ```
 
-_See code: [src/commands/plugins/update.ts](https://github.com/vtex/cli-plugin-plugins/blob/v1.10.0/src/commands/plugins/update.ts)_
+_See code: [src/commands/plugins/update.ts](https://github.com/vtex/cli-plugin-plugins/blob/v1.10.1/src/commands/plugins/update.ts)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtex/cli-plugin-plugins",
   "description": "plugins plugin for toolbelt",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "author": "vtex",
   "bugs": "https://github.com/vtex/cli-plugin-plugins/issues",
   "dependencies": {

--- a/src/modules/plugins.ts
+++ b/src/modules/plugins.ts
@@ -83,7 +83,7 @@ export default class Plugins {
         if (!plugin.valid && !this.config.plugins.find(p => p.name === '@oclif/plugin-legacy')) {
           throw invalidPluginError
         }
-        await fse.symlink(path.join(this.config.dataDir, '/client/current'), path.join(this.config.dataDir, '/node_modules/vtex'))
+        await fse.symlink(this.config.root, path.join(this.config.dataDir, '/node_modules/vtex'))
         await this.refresh(plugin.root)
         await this.add({name, tag: range || tag, type: 'user'})
       }
@@ -176,6 +176,7 @@ export default class Plugins {
     for (const p of plugins) {
       await this.refresh(path.join(this.config.dataDir, 'node_modules', p.name))
     }
+    await fse.symlink(this.config.root, path.join(this.config.dataDir, '/node_modules/vtex'))
     cli.action.stop()
   }
   /* eslint-enable no-await-in-loop */

--- a/src/modules/plugins.ts
+++ b/src/modules/plugins.ts
@@ -83,7 +83,7 @@ export default class Plugins {
         if (!plugin.valid && !this.config.plugins.find(p => p.name === '@oclif/plugin-legacy')) {
           throw invalidPluginError
         }
-        await fse.symlink(this.config.root, path.join(this.config.dataDir, '/node_modules/vtex'))
+        await fse.symlink(this.config.root, path.join(this.config.dataDir, 'node_modules', 'vtex'))
         await this.refresh(plugin.root)
         await this.add({name, tag: range || tag, type: 'user'})
       }
@@ -176,7 +176,7 @@ export default class Plugins {
     for (const p of plugins) {
       await this.refresh(path.join(this.config.dataDir, 'node_modules', p.name))
     }
-    await fse.symlink(this.config.root, path.join(this.config.dataDir, '/node_modules/vtex'))
+    await fse.symlink(this.config.root, path.join(this.config.dataDir, 'node_modules', 'vtex'))
     cli.action.stop()
   }
   /* eslint-enable no-await-in-loop */


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change `symlink` root path

#### What problem is this solving?
Installing a plugin will fail the `vtex` import if user installed `toolbelt` from other method than `AWS`

#### How should this be manually tested?
`yarn watch` on `toolbelt` repo
`vtex-test plugins install config`
`vtex-test config get cluster`

#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [X] Update `CHANGELOG.md`