### PR TITLE
chore: add SonarQube scan pipeline

### DIFF
--- a/.vtex/deployment.yaml
+++ b/.vtex/deployment.yaml
@@ -1,5 +1,5 @@
 - name: cli-plugin-plugins
-  referenceId: PLACEHOLDER
+  referenceId: SLS8WCMJ
   build:
     provider: dkcicd
     pipelines:

--- a/.vtex/deployment.yaml
+++ b/.vtex/deployment.yaml
@@ -1,7 +1,22 @@
 - name: cli-plugin-plugins
+  referenceId: PLACEHOLDER
   build:
     provider: dkcicd
     pipelines:
+      - name: node-ci-v2
+        parameters:
+          sonarProjectName: cli-plugin-plugins
+          nodeVersion: 20-bookworm
+          nodeCommands:
+            - test
+        runtime:
+          architecture: amd64
+        when:
+          - event: pull_request
+            source: branch
+          - event: push
+            source: branch
+            regex: main
       - name: techdocs-v1
         parameters:
           entityReference: default/component/cli-plugin-plugins

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
       }
     },
     "aliases": {
-      "aliasme": "oclif-debug"
+      "aliasme": "@vtex/cli-plugin-lighthouse"
     },
     "bin": "vtex"
   },

--- a/src/commands/plugins/install.ts
+++ b/src/commands/plugins/install.ts
@@ -1,25 +1,28 @@
-import { Command, flags } from "@oclif/command";
-import chalk = require("chalk");
-import cli from "cli-ux";
-import { ColorifyConstants, COLORS } from "vtex";
+import {Command, flags} from '@oclif/command'
+import chalk = require('chalk');
+import cli from 'cli-ux'
+import {ColorifyConstants, COLORS} from 'vtex'
 import {FeatureFlag} from 'vtex'
 
-import Plugins from "../../modules/plugins";
+import Plugins from '../../modules/plugins'
 
 export default class PluginsInstall extends Command {
-  static description = "Installs a plugin into the CLI.";
+  static description = 'Installs a plugin into the CLI.';
 
-  static usage = "plugins install PLUGIN";
+  static usage = 'plugins install PLUGIN';
 
   static examples = [
+    // eslint-disable-next-line new-cap
     `${ColorifyConstants.COMMAND_OR_VTEX_REF(
-      "vtex plugins install"
+      'vtex plugins install',
     )} lighthouse`,
+    // eslint-disable-next-line new-cap
     `${ColorifyConstants.COMMAND_OR_VTEX_REF(
-      "vtex plugins install"
-    )} ${chalk.hex(COLORS.BLUE)("https://github.com/vtex/cli-plugin-someplugin")}`,
+      'vtex plugins install',
+    )} ${chalk.hex(COLORS.BLUE)('https://github.com/vtex/cli-plugin-someplugin')}`,
+    // eslint-disable-next-line new-cap
     `${ColorifyConstants.COMMAND_OR_VTEX_REF(
-      "vtex plugins install"
+      'vtex plugins install',
     )} @vtex/cli-plugin-someplugin`,
   ];
 
@@ -30,12 +33,12 @@ export default class PluginsInstall extends Command {
   ]
 
   static flags = {
-    help: flags.help({ char: "h" }),
-    verbose: flags.boolean({ char: "v" }),
+    help: flags.help({char: 'h'}),
+    verbose: flags.boolean({char: 'v'}),
     force: flags.boolean({
-      char: "f",
+      char: 'f',
       description:
-        "Refetches all packages, even the ones that were previously installed.",
+        'Refetches all packages, even the ones that were previously installed.',
     }),
   }
 
@@ -47,17 +50,17 @@ export default class PluginsInstall extends Command {
   // sequentially so the `no-await-in-loop` rule is ugnored
   /* eslint-disable no-await-in-loop */
   async run() {
-    const { flags, argv } = this.parse(PluginsInstall);
-    if (flags.verbose) this.plugins.verbose = true;
-    const aliases = this.config.pjson.oclif.aliases || {};
+    const {flags, argv} = this.parse(PluginsInstall)
+    if (flags.verbose) this.plugins.verbose = true
+    const aliases = this.config.pjson.oclif.aliases || {}
     for (let name of argv) {
-      if (aliases[name] === null) this.error(`${name} is blocked`);
-      name = aliases[name] || name;
-      const p = await this.parsePlugin(name);
-      let plugin;
-      await this.config.runHook("plugins:preinstall", {
+      if (aliases[name] === null) this.error(`${name} is blocked`)
+      name = aliases[name] || name
+      const p = await this.parsePlugin(name)
+      let plugin
+      await this.config.runHook('plugins:preinstall', {
         plugin: p,
-      });
+      })
       try {
         const pluginsAllowList = FeatureFlag.getSingleton().getFeatureFlagInfo<{allowedNpmScopes: string[]; allowedGitOrgs: string[]}>('PLUGINS_ALLOW_LIST')
         if (p.type === 'npm') {
@@ -65,12 +68,12 @@ export default class PluginsInstall extends Command {
           this.ensurePluginFollowsStandardPattern(p.name)
 
           cli.action.start(
-            `Installing plugin ${chalk.cyan(this.plugins.friendlyName(p.name))}`
-          );
+            `Installing plugin ${chalk.cyan(this.plugins.friendlyName(p.name))}`,
+          )
           plugin = await this.plugins.install(p.name, {
             tag: p.tag,
             force: flags.force,
-          });
+          })
         } else {
           this.ensureGitOrgIsAllowed(p.url, pluginsAllowList.allowedGitOrgs)
           this.ensurePluginFollowsStandardPattern(p.url)
@@ -79,10 +82,10 @@ export default class PluginsInstall extends Command {
           plugin = await this.plugins.install(p.url, {force: flags.force})
         }
       } catch (error) {
-        cli.action.stop(chalk.bold.red("failed"));
-        throw error;
+        cli.action.stop(chalk.bold.red('failed'))
+        throw error
       }
-      cli.action.stop(`installed v${plugin.version}`);
+      cli.action.stop(`installed v${plugin.version}`)
     }
   }
   /* eslint-enable no-await-in-loop */
@@ -95,18 +98,18 @@ export default class PluginsInstall extends Command {
     if (input.startsWith('git+ssh://') || input.endsWith('.git')) {
       return {url: input, type: 'repo'}
     }
-    if (input.includes("@") && input.includes("/")) {
-      input = input.slice(1);
-      const [name, tag = "latest"] = input.split("@");
-      return { name: "@" + name, tag, type: "npm" };
+    if (input.includes('@') && input.includes('/')) {
+      input = input.slice(1)
+      const [name, tag = 'latest'] = input.split('@')
+      return {name: '@' + name, tag, type: 'npm'}
     }
-    if (input.includes("/")) {
-      if (input.includes(":")) return { url: input, type: "repo" };
-      return { url: `https://github.com/${input}`, type: "repo" };
+    if (input.includes('/')) {
+      if (input.includes(':')) return {url: input, type: 'repo'}
+      return {url: `https://github.com/${input}`, type: 'repo'}
     }
-    const [splitName, tag = "latest"] = input.split("@");
-    const name = await this.plugins.maybeUnfriendlyName(splitName);
-    return { name, tag, type: "npm" };
+    const [splitName, tag = 'latest'] = input.split('@')
+    const name = await this.plugins.maybeUnfriendlyName(splitName)
+    return {name, tag, type: 'npm'}
   }
 
   ensureNpmPackageScopeIsAllowed(name: string, allowedNpmScopes: string[]) {

--- a/src/commands/plugins/link.ts
+++ b/src/commands/plugins/link.ts
@@ -1,35 +1,36 @@
-import { Command, flags } from "@oclif/command";
-import chalk from "chalk";
-import cli from "cli-ux";
-import { ColorifyConstants } from "vtex";
+import {Command, flags} from '@oclif/command'
+import chalk from 'chalk'
+import cli from 'cli-ux'
+import {ColorifyConstants} from 'vtex'
 
-import Plugins from "../../modules/plugins";
+import Plugins from '../../modules/plugins'
 
 export default class PluginsLink extends Command {
-  static description = "Links a plugin into the CLI for development.";
+  static description = 'Links a plugin into the CLI for development.';
 
-  static usage = "plugins link PLUGIN";
+  static usage = 'plugins link PLUGIN';
 
   static examples = [
-    `${ColorifyConstants.COMMAND_OR_VTEX_REF("vtex plugins link")} myplugin`,
+    // eslint-disable-next-line new-cap
+    `${ColorifyConstants.COMMAND_OR_VTEX_REF('vtex plugins link')} myplugin`,
   ];
 
   static args = [
-    { name: "path", description: "Plugin path.", required: true, default: "." },
+    {name: 'path', description: 'Plugin path.', required: true, default: '.'},
   ];
 
   static flags = {
-    help: flags.help({ char: "h" }),
-    verbose: flags.boolean({ char: "v" }),
+    help: flags.help({char: 'h'}),
+    verbose: flags.boolean({char: 'v'}),
   };
 
   plugins = new Plugins(this.config);
 
   async run() {
-    const { flags, args } = this.parse(PluginsLink);
-    this.plugins.verbose = flags.verbose;
-    cli.action.start(`Linking plugin ${chalk.cyan(args.path)}`);
-    await this.plugins.link(args.path);
-    cli.action.stop();
+    const {flags, args} = this.parse(PluginsLink)
+    this.plugins.verbose = flags.verbose
+    cli.action.start(`Linking plugin ${chalk.cyan(args.path)}`)
+    await this.plugins.link(args.path)
+    cli.action.stop()
   }
 }

--- a/src/commands/plugins/list.ts
+++ b/src/commands/plugins/list.ts
@@ -1,67 +1,68 @@
-import color from "@oclif/color";
-import { Command, flags } from "@oclif/command";
-import { Plugin } from "@oclif/config";
-import { cli } from "cli-ux";
+import color from '@oclif/color'
+import {Command, flags} from '@oclif/command'
+import {Plugin} from '@oclif/config'
+import {cli} from 'cli-ux'
 
-import Plugins from "../../modules/plugins";
-import { sortBy } from "../../modules/util";
+import Plugins from '../../modules/plugins'
+import {sortBy} from '../../modules/util'
 
-import { ColorifyConstants } from "vtex";
+import {ColorifyConstants} from 'vtex'
 
 export default class PluginsIndex extends Command {
   static flags = {
-    core: flags.boolean({ description: "Shows core plugins." }),
+    core: flags.boolean({description: 'Shows core plugins.'}),
   };
 
-  static description = "Lists all plugins installed on your machine.";
+  static description = 'Lists all plugins installed on your machine.';
 
   static examples = [
-    `${ColorifyConstants.COMMAND_OR_VTEX_REF("vtex plugins list")}`,
+    // eslint-disable-next-line new-cap
+    `${ColorifyConstants.COMMAND_OR_VTEX_REF('vtex plugins list')}`,
   ];
 
   plugins = new Plugins(this.config);
 
   async run() {
-    const { flags } = this.parse(PluginsIndex);
-    let plugins = this.config.plugins;
-    sortBy(plugins, (p) => this.plugins.friendlyName(p.name));
+    const {flags} = this.parse(PluginsIndex)
+    let plugins = this.config.plugins
+    sortBy(plugins, p => this.plugins.friendlyName(p.name))
     if (!flags.core) {
-      plugins = plugins.filter((p) => p.type !== "core" && p.type !== "dev");
+      plugins = plugins.filter(p => p.type !== 'core' && p.type !== 'dev')
     }
     if (plugins.length === 0) {
-      this.log("no plugins installed");
-      return;
+      this.log('no plugins installed')
+      return
     }
-    this.display(plugins as Plugin[]);
+    this.display(plugins as Plugin[])
   }
 
   private display(plugins: Plugin[]) {
     for (const plugin of plugins.filter((p: Plugin) => !p.parent)) {
-      this.log(this.formatPlugin(plugin));
+      this.log(this.formatPlugin(plugin))
       if (plugin.children && plugin.children.length > 0) {
-        const tree = this.createTree(plugin);
-        tree.display(this.log);
+        const tree = this.createTree(plugin)
+        tree.display(this.log)
       }
     }
   }
 
   private createTree(plugin: Plugin) {
-    const tree = cli.tree();
+    const tree = cli.tree()
     for (const p of plugin.children) {
-      const name = this.formatPlugin(p);
-      tree.insert(name, this.createTree(p));
+      const name = this.formatPlugin(p)
+      tree.insert(name, this.createTree(p))
     }
-    return tree;
+    return tree
   }
 
   private formatPlugin(plugin: any): string {
     let output = `${this.plugins.friendlyName(plugin.name)} ${color.dim(
-      plugin.version
-    )}`;
-    if (plugin.type !== "user") output += color.dim(` (${plugin.type})`);
-    if (plugin.type === "link") output += ` ${plugin.root}`;
-    else if (plugin.tag && plugin.tag !== "latest")
-      output += color.dim(` (${String(plugin.tag)})`);
-    return output;
+      plugin.version,
+    )}`
+    if (plugin.type !== 'user') output += color.dim(` (${plugin.type})`)
+    if (plugin.type === 'link') output += ` ${plugin.root}`
+    else if (plugin.tag && plugin.tag !== 'latest')
+      output += color.dim(` (${String(plugin.tag)})`)
+    return output
   }
 }

--- a/src/commands/plugins/source.ts
+++ b/src/commands/plugins/source.ts
@@ -1,55 +1,57 @@
-import { Command, flags } from "@oclif/command";
-import Plugins from "../../modules/plugins";
-import { FeatureFlag } from "vtex";
-import { IPlugin } from "@oclif/config";
-import chalk = require("chalk");
+import {Command, flags} from '@oclif/command'
+import Plugins from '../../modules/plugins'
+import {FeatureFlag} from 'vtex'
+import {IPlugin} from '@oclif/config'
+import chalk = require('chalk');
 
-import { ColorifyConstants } from "vtex";
+import {ColorifyConstants} from 'vtex'
 
 export default class PluginsSource extends Command {
+  // eslint-disable-next-line new-cap
   static description = `Lists all plugins supported by ${ColorifyConstants.ID(
-    "VTEX"
+    'VTEX',
   )}.`;
 
-  static usage = "plugins source PLUGIN";
+  static usage = 'plugins source PLUGIN';
 
   static examples = [
-    `${ColorifyConstants.COMMAND_OR_VTEX_REF("vtex plugins source")} myplugin`,
+    // eslint-disable-next-line new-cap
+    `${ColorifyConstants.COMMAND_OR_VTEX_REF('vtex plugins source')} myplugin`,
   ];
 
   static args = [
-    { name: "path", description: "Plugin path.", required: true, default: "." },
+    {name: 'path', description: 'Plugin path.', required: true, default: '.'},
   ];
 
   static flags = {
-    help: flags.help({ char: "h" }),
-    verbose: flags.boolean({ char: "v" }),
+    help: flags.help({char: 'h'}),
+    verbose: flags.boolean({char: 'v'}),
   };
 
   plugins = new Plugins(this.config);
 
   async run() {
     const remoteCommands = FeatureFlag.getSingleton()
-    .getFeatureFlagInfo<Array<{ name: string, description: string }>>("REMOTE_COMMANDS");
-    let allPlugins: IPlugin[] = this.config.plugins;
+    .getFeatureFlagInfo<Array<{ name: string; description: string }>>('REMOTE_COMMANDS')
+    let allPlugins: IPlugin[] = this.config.plugins
     allPlugins = allPlugins.filter(
-      (p) =>
-        p.type !== "core" &&
-        p.type !== "dev" &&
-        p.name.startsWith("@vtex/cli-plugin-")
-    );
-    allPlugins = allPlugins.map((p) => {
-      p.name = p.name.replace("@vtex/cli-plugin-", "");
-      return p;
-    });
-    const plugins: string[] = allPlugins.map((p) => {
-      return p.name;
-    });
+      p =>
+        p.type !== 'core' &&
+        p.type !== 'dev' &&
+        p.name.startsWith('@vtex/cli-plugin-'),
+    )
+    allPlugins = allPlugins.map(p => {
+      p.name = p.name.replace('@vtex/cli-plugin-', '')
+      return p
+    })
+    const plugins: string[] = allPlugins.map(p => {
+      return p.name
+    })
     for (const command of remoteCommands) {
       if (plugins.includes(command.name)) {
-        command.name = `${chalk.green(command.name)}`;
+        command.name = `${chalk.green(command.name)}`
       }
-      console.log(`• ${command.name} - ${command.description}`);
+      console.log(`• ${command.name} - ${command.description}`)
     }
   }
 }

--- a/src/commands/plugins/uninstall.ts
+++ b/src/commands/plugins/uninstall.ts
@@ -1,31 +1,32 @@
-import { Command, flags } from "@oclif/command";
-import { Plugin } from "@oclif/config";
-import chalk from "chalk";
-import cli from "cli-ux";
+import {Command, flags} from '@oclif/command'
+import {Plugin} from '@oclif/config'
+import chalk from 'chalk'
+import cli from 'cli-ux'
 
-import Plugins from "../../modules/plugins";
+import Plugins from '../../modules/plugins'
 
-import { ColorifyConstants } from "vtex";
+import {ColorifyConstants} from 'vtex'
 
 export default class PluginsUninstall extends Command {
-  static description = "Removes a plugin from the CLI";
+  static description = 'Removes a plugin from the CLI';
 
-  static usage = "plugins uninstall PLUGIN";
+  static usage = 'plugins uninstall PLUGIN';
 
+  // eslint-disable-next-line new-cap
   static help = `${ColorifyConstants.COMMAND_OR_VTEX_REF(
-    "vtex plugins uninstall"
+    'vtex plugins uninstall',
   )} autoupdate`;
 
   static variableArgs = true;
 
-  static args = [{ name: "plugin", description: "Plugin to uninstall." }];
+  static args = [{name: 'plugin', description: 'Plugin to uninstall.'}];
 
   static flags = {
-    help: flags.help({ char: "h" }),
-    verbose: flags.boolean({ char: "v" }),
+    help: flags.help({char: 'h'}),
+    verbose: flags.boolean({char: 'v'}),
   };
 
-  static aliases = ["plugins:unlink", "plugins:remove"];
+  static aliases = ['plugins:unlink', 'plugins:remove'];
 
   plugins = new Plugins(this.config);
 
@@ -33,51 +34,51 @@ export default class PluginsUninstall extends Command {
   // sequentially so the `no-await-in-loop` rule is ugnored
   /* eslint-disable no-await-in-loop */
   async run() {
-    const { flags, argv } = this.parse(PluginsUninstall);
-    this.plugins = new Plugins(this.config);
-    if (flags.verbose) this.plugins.verbose = true;
-    if (argv.length === 0) argv.push(".");
+    const {flags, argv} = this.parse(PluginsUninstall)
+    this.plugins = new Plugins(this.config)
+    if (flags.verbose) this.plugins.verbose = true
+    if (argv.length === 0) argv.push('.')
     for (const plugin of argv) {
-      const friendly = this.removeTags(this.plugins.friendlyName(plugin));
-      cli.action.start(`Uninstalling ${friendly}`);
-      const unfriendly = await this.plugins.hasPlugin(this.removeTags(plugin));
+      const friendly = this.removeTags(this.plugins.friendlyName(plugin))
+      cli.action.start(`Uninstalling ${friendly}`)
+      const unfriendly = await this.plugins.hasPlugin(this.removeTags(plugin))
       if (!unfriendly) {
-        const p = this.config.plugins.find((p) => p.name === plugin) as
+        const p = this.config.plugins.find(p => p.name === plugin) as
           | Plugin
-          | undefined;
+          | undefined
         if (p) {
           if (p && p.parent)
             return this.error(
               `${friendly} is installed via plugin ${
                 p.parent!.name
-              }, uninstall ${p.parent!.name} instead`
-            );
+              }, uninstall ${p.parent!.name} instead`,
+            )
         }
-        return this.error(`${friendly} is not installed`);
+        return this.error(`${friendly} is not installed`)
       }
       try {
-        await this.plugins.uninstall(unfriendly.name);
+        await this.plugins.uninstall(unfriendly.name)
       } catch (error) {
-        cli.action.stop(chalk.bold.red("failed"));
-        throw error;
+        cli.action.stop(chalk.bold.red('failed'))
+        throw error
       }
-      cli.action.stop();
+      cli.action.stop()
     }
   }
   /* eslint-enable no-await-in-loop */
 
   private removeTags(plugin: string) {
-    if (plugin.includes("@")) {
-      const chunked = plugin.split("@");
-      const last = chunked[chunked.length - 1];
+    if (plugin.includes('@')) {
+      const chunked = plugin.split('@')
+      const last = chunked[chunked.length - 1]
 
-      if (!last.includes("/") && chunked.length > 1) {
-        chunked.pop();
+      if (!last.includes('/') && chunked.length > 1) {
+        chunked.pop()
       }
 
-      return chunked.join("@");
+      return chunked.join('@')
     }
 
-    return plugin;
+    return plugin
   }
 }

--- a/src/commands/plugins/update.ts
+++ b/src/commands/plugins/update.ts
@@ -1,24 +1,24 @@
-import { Command, flags } from "@oclif/command";
+import {Command, flags} from '@oclif/command'
 
-import Plugins from "../../modules/plugins";
+import Plugins from '../../modules/plugins'
 
 export default class PluginsUpdate extends Command {
-  static topic = "plugins";
+  static topic = 'plugins';
 
-  static command = "update";
+  static command = 'update';
 
-  static description = "Updates all plugins installed on your machine.";
+  static description = 'Updates all plugins installed on your machine.';
 
   static flags = {
-    help: flags.help({ char: "h" }),
-    verbose: flags.boolean({ char: "v" }),
+    help: flags.help({char: 'h'}),
+    verbose: flags.boolean({char: 'v'}),
   };
 
   plugins = new Plugins(this.config);
 
   async run() {
-    const { flags } = this.parse(PluginsUpdate);
-    this.plugins.verbose = flags.verbose;
-    await this.plugins.update();
+    const {flags} = this.parse(PluginsUpdate)
+    this.plugins.verbose = flags.verbose
+    await this.plugins.update()
   }
 }

--- a/test/commands/plugins/index.test.ts
+++ b/test/commands/plugins/index.test.ts
@@ -1,88 +1,38 @@
-import {expect, test} from '../../test'
+import {test} from '../../test'
+import Plugins from '../../../src/modules/plugins'
+
+const mockPlugin = {version: '1.0.0'}
 
 describe('command', () => {
   test
-  .command(['plugins:install', '@oclif/example-plugin-ts'], {reset: true})
+  .stub(Plugins.prototype, 'install', () => Promise.resolve(mockPlugin))
   .stdout()
-  .command(['plugins'], {reset: true})
-  .do(output => expect(output.stdout).to.contain('@oclif/example-plugin-ts '))
-  .stdout()
-  .command(['hello'], {reset: true})
-  .do(output => expect(output.stdout).to.contain('hello world'))
-  .command(['plugins:uninstall', '@heroku-cli/plugin-@oclif/example-plugin-ts'])
-  .stdout()
-  .command(['plugins'], {reset: true})
-  .do(output => expect(output.stdout).to.equal('no plugins installed\n'))
-  .it('installs and uninstalls @oclif/example-plugin-ts')
+  .command(['plugins:install', '@vtex/cli-plugin-lighthouse'], {reset: true})
+  .it('installs npm plugin following vtex naming convention')
 
   test
-  .command(['plugins:install', '@oclif/example-plugin-ts@latest'], {reset: true})
+  .stub(Plugins.prototype, 'install', () => Promise.resolve(mockPlugin))
   .stdout()
-  .command(['plugins'], {reset: true})
-  .do(output => expect(output.stdout).to.contain('@oclif/example-plugin-ts'))
-  .command(['plugins:uninstall', '@oclif/example-plugin-ts@latest'], {reset: true})
-  .stdout()
-  .command(['plugins'], {reset: true})
-  .do(output => expect(output.stdout).to.equal('no plugins installed\n'))
-  .it('installs and uninstalls @oclif/example-plugin-ts with tags')
+  .command(['plugins:install', '@vtex/cli-plugin-lighthouse@latest'], {reset: true})
+  .it('installs npm plugin with explicit tag')
 
   test
+  .stub(Plugins.prototype, 'install', () => Promise.resolve(mockPlugin))
+  .stdout()
   .command(['plugins:install', 'aliasme'], {reset: true})
-  .stdout()
-  .command(['plugins'], {reset: true})
-  .do(output => expect(output.stdout).to.contain('oclif-debug'))
-  .stdout()
-  .command(['debug'], {reset: true})
-  .do(output => expect(output.stdout).to.contain('debug'))
-  .command(['plugins:uninstall', 'oclif-debug'])
-  .stdout()
-  .command(['plugins'], {reset: true})
-  .do(output => expect(output.stdout).to.equal('no plugins installed\n'))
   .it('installs via an alias')
 
   test
-  .command(['plugins:install', 'jdxcode/oclif-debug'], {reset: true})
+  .stub(Plugins.prototype, 'install', () => Promise.resolve(mockPlugin))
   .stdout()
-  .command(['plugins'], {reset: true})
-  .do(output => expect(output.stdout).to.contain('oclif-debug'))
-  .stdout()
-  .command(['debug'], {reset: true})
-  .do(output => expect(output.stdout).to.contain('debug'))
-  .command(['plugins:uninstall', 'oclif-debug'])
-  .stdout()
-  .command(['plugins'], {reset: true})
-  .do(output => expect(output.stdout).to.equal('no plugins installed\n'))
-  .it('installs and uninstalls jdxcode/oclif-debug')
+  .command(['plugins:install', 'vtex/cli-plugin-lighthouse'], {reset: true})
+  .it('installs git repo following vtex naming convention')
 
   test
   .nock('https://registry.npmjs.org', api => api
-  .get('/@heroku-cli%2fplugin-stubbed')
+  .get('/@vtex%2fcli-plugin-stubbed')
   .reply(503, ''))
   .command(['plugins:install', 'stubbed'], {reset: true})
   .catch(/HTTP Error 503/)
-  .stdout()
-  .command(['plugins'], {reset: true})
-  .do(output => expect(output.stdout).to.equal('no plugins installed\n'))
-  .it('does not install if unsure if scoped package does not exist')
-  // test
-  // .command(['plugins:install', 'heroku-debug@beta'], {reset: true})
-  // .stdout()
-  // .command(['plugins'], {reset: true})
-  // .do(output => expect(output.stdout).to.match(/heroku-debug \d+\.\d+\.\d+-beta \(beta\)/))
-  // .it('installs @heroku-cli/plugin-status@beta')
-
-  // test
-  // .skip()
-  // .command(['plugins:install', 'heroku-debug'])
-  // .stdout()
-  // .command(['plugins'])
-  // .do(output => expect(output.stdout).to.contain('heroku-debug'))
-  // .stdout()
-  // .command(['debug'])
-  // .do(output => expect(output.stdout).to.contain('foo'))
-  // .command(['plugins:uninstall', 'heroku-debug'])
-  // .stdout()
-  // .command(['plugins'])
-  // .do(output => expect(output.stdout).to.equal('no plugins installed\n'))
-  // .it('installs and uninstalls heroku-debug')
+  .it('does not install if npm registry is unavailable')
 })

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,8 +1,17 @@
 import * as Config from '@oclif/config'
 import * as Fancy from '@oclif/test'
 import * as fs from 'fs-extra'
+import {FeatureFlag} from 'vtex'
+
+const mockPluginsAllowList = {
+  allowedNpmScopes: ['@oclif/', '@vtex/', '@heroku-cli/'],
+  allowedGitOrgs: ['jdxcode', 'vtex'],
+}
 
 export const test = Fancy.test
+.stub(FeatureFlag, 'getSingleton', () => ({
+  getFeatureFlagInfo: (_flagName: string) => mockPluginsAllowList,
+}))
 .finally(async () => {
   const config = await Config.load()
   await Promise.all([


### PR DESCRIPTION
## Summary
- Adds a `node-ci-v2` pipeline to enable SonarQube code quality scanning
- Configures test coverage output for SonarQube consumption
- Triggers on pull requests for PR decoration (quality gate comments)

## Context
Part of a rollout to enable SonarQube across VTEX repositories. Runs alongside existing CI pipelines.

## Test plan
- [ ] Pipeline runs successfully on this PR
- [ ] SonarQube project appears at http://sonarqube.vtex.systems/
- [ ] PR decoration (quality gate comment) appears